### PR TITLE
Use regex for whitespaces when checking login.defs

### DIFF
--- a/cat_2/UBTU-22-411xxx/UBTU-22-411025.yml
+++ b/cat_2/UBTU-22-411xxx/UBTU-22-411025.yml
@@ -8,7 +8,7 @@ file:
     path: /etc/login.defs
     exists: true
     contents:
-    - '/^PASS_MIN_DAYS 1/'
+    - '/^PASS_MIN_DAYS\s+1/'
     meta:
       Cat: 2
       CCI: NA

--- a/cat_2/UBTU-22-411xxx/UBTU-22-411030.yml
+++ b/cat_2/UBTU-22-411xxx/UBTU-22-411030.yml
@@ -8,7 +8,7 @@ file:
     path: /etc/login.defs
     exists: true
     contents:
-    - '/^PASS_MAX_DAYS (60|[1-5][0-9])$/'
+    - '/^PASS_MAX_DAYS\s+(60|[1-5][0-9])$/'
     meta:
       Cat: 2
       CCI: NA


### PR DESCRIPTION
**Overall Review of Changes:**
As per [login.defs definition](https://man7.org/linux/man-pages/man5/login.defs.5.html) in linux manual, configuration name and values are separated by whitespace; which means it supports both space and tab. We can also see these key values are separated by multiple whitespaces in some cases (e.g. https://github.com/shadow-maint/shadow/blob/b4beda846c4bd2c54d2b246ec18948acc47502c1/etc/login.defs#L12)

This PR aims to fix audit for STIGS UBTU-22-411025 and UBTU-22-411030.

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

