### PR TITLE
Support various root id method & kernel location in grub config for UBTU-22-212015

### DIFF
--- a/cat_2/UBTU-22-21xxxx/UBTU-22-212015.yml
+++ b/cat_2/UBTU-22-21xxxx/UBTU-22-212015.yml
@@ -8,8 +8,8 @@ file:
     path:  /boot/grub/grub.cfg
     exists: true
     contents:
-    - '/^\s*linux\s*\/vmlinuz-.*root=/dev/mapper.*audit=1.*/'
-    - '!/^\s*linux\s*\/vmlinuz-.*root=/dev/mapper.*audit=0.*/'
+    - '/^\s*linux\s*.*\/vmlinuz-.*root=.*audit=1.*/'
+    - '!/^\s*linux\s*.*\/vmlinuz-.*root=.*audit=0.*/'
     meta:
       Cat: 2
       CCI: CCI-001464


### PR DESCRIPTION
**Overall Review of Changes:**
There are multiple ways to provide id for root, described [here](https://www.gnu.org/software/grub/manual/grub/html_node/Root-Identifcation-Heuristics.html).
The kernel also can be located in `/boot/`.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Manually

