### PR TITLE
Add secrets block and *qa_report* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,22 @@ benchparse/
 *xccdf.xml
 *history.md
 *plan.md
+*qa_report*
 prompt.md
 *.py
 *.retry
+
+# Secrets / keys
+*.vault
+*.key
+*.pem
+*.p12
+*.pfx
+*.keystore
+*.jks
+*.credentials
+*vault_pass*
+.vault_pass
 
 # GitHub Action/Workflow files
 .github/


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Hygiene-only. Adds a secrets/keys ignore block (`*.vault`, `*.key`, `*.pem`, `*vault_pass*`, etc.) and `*qa_report*` to .gitignore so credential material and QA report artifacts cannot be accidentally committed. No functional/audit-content changes.

**Issue Fixes:**
N/A

**Enhancements:**
- .gitignore: secrets/keys block + `*qa_report*`.

**How has this been tested?:**
N/A - .gitignore only.